### PR TITLE
Remove pdb as a dependency

### DIFF
--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import torch
 import torch.optim
-import pdb
 import logging
 import os
 import torch.distributed as dist


### PR DESCRIPTION
Currently `pdb` is force installed when pip installing this repo. Can we maybe remove it here?