### PR TITLE
Text Encoder LR Scale for Stable Diffusion Training

### DIFF
--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -81,7 +81,8 @@ class Prodigy(torch.optim.Optimizer):
                         k=0, growth_rate=growth_rate,
                         use_bias_correction=use_bias_correction,
                         decouple=decouple, safeguard_warmup=safeguard_warmup,
-                        fsdp_in_use=fsdp_in_use, te_scale=te_scale) # te_scale added to defaults
+                        fsdp_in_use=fsdp_in_use, te_scale=te_scale, # te_scale added to defaults
+                        full_dlr=None, te_dlr=None) # parameters to log and debug the learning rates
         self.d0 = d0
         super().__init__(params, defaults)
 
@@ -221,6 +222,8 @@ class Prodigy(torch.optim.Optimizer):
             group['d'] = d
             group['d_max'] = d_max
             group['d_hat'] = d_hat
+            group["full_dlr"] = dlr # log and debug for normal dlr
+            group["te_dlr"] = (dlr * te_scale) # log and debug for the new te dlr
 
             decay = group['weight_decay']
             k = group['k']


### PR DESCRIPTION
Hello! This is a suggested implementation to scale the magnitude of the Text Encoder's learning rate during Stable Diffusion training sessions.

So, I'm another user of the stable diffusion community, and, like many others, I really enjoy training using Prodigy. However, as we know, many people come here to find a solution to the overtraining of the TE, since Prodigy doesn't accept different LRs.

Just so you know, I've been using [Kohya's](https://github.com/kohya-ss/sd-scripts) scripts and training LoRAs for SD 1.5.

After analyzing how Prodigy receives and handles tensors, I came up with a trick to reduce the LR of the TE during the `.step()`.

Btw, correct me if I'm wrong, please.

I based this on the premise that TE tensors will always be 2D, so their shape will always have two dimensions.

As the tensors from Kohya come in two groups, using `all(len(p.shape) == 2 for p in group["params"])` allowed me to determine which group of tensors belongs to the TE.

With that information, I created a boolean and used an if-else statement for the weight update:

```
            is_text_encoder = all(len(p.shape) == 2 for p in group["params"])

            ...

                ### Take step
                # and here we apply the new te scale to the weight update
                if is_text_encoder:
                    # scale down the weight update for TE due his higher sensitivity
                    p.data.addcdiv_(exp_avg, denom, value=-(dlr * te_scale))
                else:
                    # standard weight update for other parameters
                    p.data.addcdiv_(exp_avg, denom, value=-dlr)
```

My approach will only influence the optimizer if the user sets the `te_scale` in the optimizer's extra arguments before starting the training. Otherwise, `te_scale` will be 1, and nothing will change in the weight update.
