### PR TITLE
Slicing parameters - large VRAM savings

### DIFF
--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import torch
 import torch.optim
-import pdb
 import logging
 import os
 import torch.distributed as dist

--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -53,8 +53,8 @@ class Prodigy(torch.optim.Optimizer):
             will attempt to auto-detect this, but if you're using an implementation other
             than PyTorch's builtin version, the auto-detection won't work.
         slice_p (int): Reduce memory usage by calculating LR adaptation statistics on only every 
-            pth entry of each tensor. For values > 1 this an an approximation to standard 
-            Prodigy. Values ~10 are reasonable (default 1).
+            pth entry of each tensor. For values greater than 1 this an an approximation to standard 
+            Prodigy. Values ~11 are reasonable (default 1).
     """
     def __init__(self, params, lr=1.0,
                  betas=(0.9, 0.999), beta3=None,

--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import torch
 import torch.optim
+import pdb
 import logging
 import os
 import torch.distributed as dist
@@ -58,7 +59,8 @@ class Prodigy(torch.optim.Optimizer):
                  eps=1e-8, weight_decay=0, decouple=True, 
                  use_bias_correction=False, safeguard_warmup=False,
                  d0=1e-6, d_coef=1.0, growth_rate=float('inf'),
-                 fsdp_in_use=False):
+                 fsdp_in_use=False,
+                 slice_p=1):
         if not 0.0 < d0:
             raise ValueError("Invalid d0 value: {}".format(d0))
         if not 0.0 < lr:
@@ -81,7 +83,8 @@ class Prodigy(torch.optim.Optimizer):
                         k=0, growth_rate=growth_rate,
                         use_bias_correction=use_bias_correction,
                         decouple=decouple, safeguard_warmup=safeguard_warmup,
-                        fsdp_in_use=fsdp_in_use)
+                        fsdp_in_use=fsdp_in_use,
+                        slice_p=slice_p)
         self.d0 = d0
         super().__init__(params, defaults)
 
@@ -140,6 +143,7 @@ class Prodigy(torch.optim.Optimizer):
             group_lr = group['lr']
             d0 = group['d0']
             safeguard_warmup = group['safeguard_warmup']
+            slice_p = group['slice_p']
 
             if group_lr not in [lr, 0.0]:
                 raise RuntimeError(f"Setting different lr values in different parameter groups is only supported for values of 0")
@@ -161,8 +165,8 @@ class Prodigy(torch.optim.Optimizer):
                 # State initialization
                 if 'step' not in state:
                     state['step'] = 0
-                    state['s'] = torch.zeros_like(p.data).detach()
-                    state['p0'] = p.detach().clone()
+                    state['s'] = torch.zeros_like(p.data.flatten()[::slice_p]).detach()
+                    state['p0'] = p.flatten()[::slice_p].detach().clone()
                     # Exponential moving average of gradient values
                     state['exp_avg'] = torch.zeros_like(p.data).detach()
                     # Exponential moving average of squared gradient values
@@ -175,16 +179,17 @@ class Prodigy(torch.optim.Optimizer):
 
                 if group_lr > 0.0:
                     # we use d / d0 instead of just d to avoid getting values that are too small
-                    d_numerator += (d / d0) * dlr * torch.dot(grad.flatten(), (p0.data - p.data).flatten()).item()
+                    sliced_grad = grad.flatten()[::slice_p]
+                    d_numerator += (d / d0) * dlr * torch.dot(sliced_grad, p0.data - p.data.flatten()[::slice_p]).item()
 
                     # Adam EMA updates
                     exp_avg.mul_(beta1).add_(grad, alpha=d * (1-beta1))
                     exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=d * d * (1-beta2))
 
                     if safeguard_warmup:
-                        s.mul_(beta3).add_(grad, alpha=((d / d0) * d))
+                        s.mul_(beta3).add_(sliced_grad, alpha=((d / d0) * d))
                     else:
-                        s.mul_(beta3).add_(grad, alpha=((d / d0) * dlr))
+                        s.mul_(beta3).add_(sliced_grad, alpha=((d / d0) * dlr))
                     d_denom += s.abs().sum().item()
 
             ######


### PR DESCRIPTION
As you know, Prodigy uses 4 internal states for each training parameter, resulting in a large VRAM footprint. AdamW in comparison uses 2 states per parameter.

These additional 2 states, p0 and s, are used to calculate d and estimate the learning rate. 

Experiments show that it is not necessary (for large models) to store p0 and s for each and every training parameter. An equally good estimation of the learning rate can be achieved by only using a fraction of the training parameters.

This PR introduces a new hyperparameter "slice_p". A value of 10 only uses every 10th training parameter for estimating the learning rate.
This has been tested using OneTrainer on the following models, with a significant impact on VRAM requirements:

| Model | Prodigy | Prodigy sliced | AdamW |
|--------|--------|--------|--------|
| Flux Dev LoRA Rank 128 | 12,1 GB | **10,7 GB** | 10.5 GB |
| SDXL full unet finetune | 31,9 GB | **22,6 GB** | 21,7 GB |

LR estimations are very similar between 'Prodigy' and 'Prodigy sliced'; so are training results.
slice_p was 10. VRAM values given are total VRAM values used by OneTrainer, not only Prodigy overhead.

Note: the default for slice_p in this PR is 1, resulting in no change!
Set a higher value if you want to test this PR.

