### PR TITLE
Save VRAM using 0-Tensors

### DIFF
--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -162,7 +162,10 @@ class Prodigy(torch.optim.Optimizer):
                 if 'step' not in state:
                     state['step'] = 0
                     state['s'] = torch.zeros_like(p.data).detach()
-                    state['p0'] = p.detach().clone()
+                    if p.count_nonzero() > 0:
+                        state['p0'] = p.detach().clone()
+                    else: state['p0'] = torch.tensor(0, device=p.device, dtype=p.dtype)
+
                     # Exponential moving average of gradient values
                     state['exp_avg'] = torch.zeros_like(p.data).detach()
                     # Exponential moving average of squared gradient values


### PR DESCRIPTION
Depending on the trained model, many of the parameters are initialized to a known value. Most often, LoRA training initializes half of its parameters to 0 and the other half to a Gaussian distribution.

In these cases, Prodigy doesn't have to save these values as p0, occupying VRAM. The VRAM overhead of Prodigy can be reduced by up to 25% (1 of 4 internal states).

This PR implements the simpler half of this optimization: If a parameter tensor is initially only 0s, a 0-tensor is used to represent this tensor in p0 instead of a tensor full of 0s

Therefore saves 12.5% of VRAM for LoRA training.

