### PR TITLE
more VRAM savings: no first moment and factored second moment

### DIFF
--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -109,8 +109,6 @@ class Prodigy(torch.optim.Optimizer):
     def _rms(tensor):
         return torch.linalg.norm(tensor) / (tensor.numel() ** 0.5)
 
-
-
     def step(self, closure=None):
         """Performs a single optimization step.
 
@@ -127,7 +125,6 @@ class Prodigy(torch.optim.Optimizer):
         group = self.param_groups[0]
         use_bias_correction = group['use_bias_correction']
         beta1, beta2 = group['betas']
-
         beta3 = group['beta3']
         if beta3 is None:
             beta3 = math.sqrt(beta2)
@@ -184,7 +181,6 @@ class Prodigy(torch.optim.Optimizer):
                     state['step'] = 0
                     state['s'] = torch.zeros_like(p.data).detach()
                     state['p0'] = p.detach().clone()
-
                     # Exponential moving average of gradient values
                     if beta1 > 0:
                         state['exp_avg'] = torch.zeros_like(p).detach()
@@ -307,4 +303,5 @@ class Prodigy(torch.optim.Optimizer):
             group['k'] = k + 1
 
         return loss
+        
 

--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -297,7 +297,7 @@ class Prodigy(torch.optim.Optimizer):
                         exp_avg = state['exp_avg']
                         update=exp_avg.div(denom)
                     else: update=grad.div(denom).mul_(d)
-                    clip_div=self._rms(update).clamp_(min=update_clip)
+                    clip_div=(self._rms(update) / update_clip).clamp_(min=1.0)
                     p.data.add_(update,alpha = -dlr / clip_div)
 
 

--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -225,9 +225,9 @@ class Prodigy(torch.optim.Optimizer):
                         exp_avg_sq_row = state["exp_avg_sq_row"]
                         exp_avg_sq_col = state["exp_avg_sq_col"]
 
-                        grad_sq=grad.square()+eps2
-                        exp_avg_sq_row.mul_(beta2).add_(grad_sq.mean(dim=-1), alpha=d * d * (1-beta2))
-                        exp_avg_sq_col.mul_(beta2).add_(grad_sq.mean(dim=-2), alpha=d * d * (1-beta2))
+                        grad_sq=grad.square()
+                        exp_avg_sq_row.mul_(beta2).add_(grad_sq.mean(dim=-1), alpha=d * d * (1-beta2)).add_(eps2)
+                        exp_avg_sq_col.mul_(beta2).add_(grad_sq.mean(dim=-2), alpha=d * d * (1-beta2)).add_(eps2)
 
                     if safeguard_warmup:
                         s.mul_(beta3).add_(sliced_grad, alpha=((d / d0) * d))

--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -293,9 +293,10 @@ class Prodigy(torch.optim.Optimizer):
                         p.data.addcdiv_(exp_avg, denom, value=-dlr)
                     else: p.data.addcdiv_(grad, denom, value=-dlr * d)
                 else:
-                    if beta1 > 0: update=exp_avg.div(denom)
+                    if beta1 > 0:
+                        exp_avg = state['exp_avg']
+                        update=exp_avg.div(denom)
                     else: update=grad.div(denom).mul_(d)
-                    
                     clip_div=self._rms(update).clamp_(min=update_clip)
                     p.data.add_(update,alpha = -dlr / clip_div)
 


### PR DESCRIPTION
This is another PR with the intention of making Prodigy usable on low-vram systems and large models.

Combined with https://github.com/konstmish/prodigy/pull/22, the vram overhead by Prodigy can be reduced by roughly 95%.

Total VRAM usage by OneTrainer again as examples:
| Model | Prodigy | Prodigy sliced&factored | AdamW |
|--------|--------|--------|--------|
| Flux Dev LoRA Rank 128 | 12,1 GB | **9,0 GB** | 10.5 GB |
| SDXL full unet finetune | 31,9 GB | **12,6 GB** | 21,7 GB |

This is achieved by some of the concepts proposed in this paper https://arxiv.org/pdf/1804.04235. This PR therefore goes a bit beyond the scope of your paper.

I'd still propose to merge these PRs, because your repo is in wide production use, but limited by its large VRAM footprint.
You can always make a fork of the code, for people just interested in the code accompanying the paper.

This PR does 3 things:

1. 
The paper above has shown that the first EMA can be disabled and only the second moment be used, and still achieve good training results. Prodigy can already do that by setting `beta1` to 0, but with this PR it also doesn't allocate any VRAM anymore towards the then-unused `exp_avg` state.

This saves 25% of vram.

2.
if `factored` is set to `True`, it doesn't store a full tensor for the second EMA anymore, but a factored approximation. Details can be found in the paper above.

Depending on the shape of the model's parameters, this saves another 24 - 25% of vram.

3.
The approximation of the second moment above can introduce unwanted spikes in parameter updates, that are not caught by regular gradient clipping. If `update_clip` is set to `True`, it does another round of clipping after the EMA has been applied to the gradients.
This makes a clearly noticeable difference when using the above, but I suspect this might even be beneficial for Prodigy independently of these vram optimizations:
People have reported having problems with a high beta2 setting and Prodigy here:
https://github.com/konstmish/prodigy/issues/8

This could be caused by the rapid changes in learning rate by Prodigy, that increase the variance of gradients, while the second moment EMA is out-of-date and indicating still a low variance. At a high beta2 this can be the case for a long time.
Large parameter updates are the result as shown here: ![grafik](https://github.com/user-attachments/assets/b1499255-092e-4023-8e9f-0cb8a58c390e)

Update clipping scales down the parameter updates, not only the gradients before EMA.

The remaining 45% of 95% vram savings mentioned above are by https://github.com/konstmish/prodigy/pull/22

Note again: the code with default settings doesn't have any effect. Set the values mentioned above if you want to test this PR.
This PR is only the part described above. I have a merge of all 3 PRs in my github fork if you want to test everything together.