### PR TITLE
more vram savings: fused backpass

### DIFF
--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -215,9 +215,13 @@ class Prodigy(torch.optim.Optimizer):
         loss = None
         if closure is not None:
             loss = closure()
+
+        #if step_parameter() was called for all parameter during a fused backpass,
+        #all gradients are None and this loop won't do anything:
         for group in self.param_groups:
             for i, p in enumerate(group["params"]):
                 self.step_parameter(p, group, i)
+
         self.calculate_d()
         self.init_step() #first init_step is called in __init__
         return loss


### PR DESCRIPTION
Fused backpass is another technique to save vram. It is mostly implemented in the host trainer, not the optimizer - but it does need a little support from the optimizer.

Effects are significant:
| Model | Prodigy | + sliced&factored | + fused backpass | AdamW |
|--------|--------|--------|--------|--------|
| Flux Dev NF4 LoRA Rank 128 | 12,1 GB | 9,0 GB | **8,4 GB** | 10.5 GB |
| SDXL bf16 full unet finetune | 31,9 GB | 12,6 GB | **7,9 GB**  | 21,7 GB |
| Flux Dev bf16 full finetune | approx. 144 GB | approx. 53 GB | (**15,1 GB**) | approx. 96 GB |

Fused back pass is a known technique described here:
https://pytorch.org/tutorials/intermediate/optimizer_step_in_backward_tutorial.html

By applying the gradients during the backpass, you can get rid of almost the entire gradient buffer, thereby saving vram.

To support this method, the optimizer has to provide a method called `step_parameter()`, that makes an optimizer step for a single parameter tensor. This is what this PR is about:
Re-factoring the code, so that the calculation of `d` once per optimizer step, and the inner loops that apply the gradients, are separated.

Would you support making these changes?
Making these changes downstream in the training tool would require copying the entire code of Prodigy. I'd prefer to keep the code synced.
This is only a draft, some things could be made nicer. My focus was on not breaking things and changing as little as possible.

The last line in the table above is fine tuning a 12B model in bf16 precision using fused backpass, but also a sophisticated async offloading technique recently developed by @Nerogar. With minimal performance impact, it offloads parts of the model that are currently not used to RAM. Even very large models can be trained on consumer hardware.
It doesn't require anything additional of the optimizer, but it does require the fused backpass described above.
Here is a technical description:
https://github.com/Nerogar/OneTrainer/blob/3963bb2a4eea9a894fa39c151987fa5816da15e2/docs/RamOffloading.md

The other lines in the table are only using fused backpass.