### PR TITLE
Faster check for zero-tensors

### DIFF
--- a/prodigyopt/prodigy.py
+++ b/prodigyopt/prodigy.py
@@ -170,9 +170,10 @@ class Prodigy(torch.optim.Optimizer):
 
                     state['s'] = torch.zeros_like(p.data.flatten()[::slice_p]).detach()
 
-                    if p.count_nonzero() > 0:
+                    if p.any():
                         state['p0'] = p.flatten()[::slice_p].detach().clone()
-                    else: 
+                    else:
+                        # All values are zero, so save VRAM with a zero-tensor
                         state['p0'] = torch.tensor(0, device=p.device, dtype=p.dtype)
 
                     # Exponential moving average of gradient values


### PR DESCRIPTION
The current code loops through the whole tensor and counts all non-zero values. Looping and counting is slow.

We can instead call `any()` which returns True as soon as it finds the first non-zero value, it's much faster, saving some initialization time.

https://pytorch.org/docs/stable/generated/torch.any.html#torch.any

I have validated its behavior with Torch's CUDA backend (on "2.3.1+cu118"):

```
>>> import torch
>>> x = torch.tensor([0.0, -0.5, 1.2, 50.3])
>>> y = torch.tensor([0.0, 0.0, 0.0, 0.0])
>>> z = torch.tensor([999.0, -0.5, 1.2, 50.3])
>>> x.any()
tensor(True)
>>> y.any()
tensor(False)
>>> z.any()
tensor(True)
>>> nearzero = torch.tensor([-0.1, 0.05, 0.3])
>>> nearzero.any()
tensor(True)
>>> practicallyzero = torch.tensor([0.00000000000001, 0.0, 0.0])
>>> practicallyzero.any()
tensor(True)
```

So `any()` immediately returns True if **any** of the tensor values are non-zero/non-False. It only returns False if _all values_ are zero/False. That's what we want. A fast check for non-zero tensors. We have no reason to _count_ every value. :)

Edit: Have also verified in real LoRA training now. This check accurately and quickly detects the empty tensors. So it's safe to merge.